### PR TITLE
Record attachments' content types in action_data of CallbackEvent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef#egg=py-trello
 psycopg2==2.7.4
+requests==2.18.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 flake8
 mock==2.0
 coverage==4.2
+responses

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -280,6 +280,11 @@ class CallbackEvent(models.Model):
         return self.event_payload.get('action', {}).get('memberCreator')
 
     @property
+    def attachment(self):
+        """Returns 'attachment' JSON extracted from event_payload."""
+        return self.action_data.get('attachment') if self.action_data else None
+
+    @property
     def board(self):
         """Returns 'board' JSON extracted from event_payload."""
         return self.action_data.get('board') if self.action_data else None

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 
 from jsonfield import JSONField
 import trello
-from requests import RequestException
 
 from trello_webhooks import settings
 from trello_webhooks import signals

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -227,7 +227,12 @@ class Webhook(models.Model):
             webhook=self,
             event_type=action,
             event_payload=body_text
-        ).save()
+        )
+        attachment = payload['action'].get('data', {}).get('attachment', {})
+        if attachment and attachment.get('url'):
+            attachment['contentType'] = event.fetch_attachment_content_type()
+            event.event_payload = json.dumps(payload)
+        event.save()
         self.touch()
         signals.callback_received.send(sender=self.__class__, event=event)
         return event

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -2,6 +2,7 @@
 import json
 import logging
 
+import requests
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.template import TemplateDoesNotExist
@@ -10,6 +11,7 @@ from django.utils import timezone
 
 from jsonfield import JSONField
 import trello
+from requests import RequestException
 
 from trello_webhooks import settings
 from trello_webhooks import signals
@@ -283,6 +285,16 @@ class CallbackEvent(models.Model):
     def attachment(self):
         """Returns 'attachment' JSON extracted from event_payload."""
         return self.action_data.get('attachment') if self.action_data else None
+
+    def fetch_attachment_content_type(self):
+        """Returns the content type of the attachment if it exists.
+
+        Returns None if there is no attachment
+
+        May raise an exception if the API request to Trello fails"""
+        if self.attachment:
+            response = requests.head(self.attachment['url'])
+            return response.headers['Content-Type']
 
     @property
     def board(self):

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,174 @@
+
+
+{
+  "action": {
+    "data": {
+      "attachment": {
+        "edgeColor": "#acb4ac",
+        "id": "5b053579753db133b2341d3d",
+        "name": "1.JPG",
+        "previewUrl": "https://trello-attachments.s3.amazonaws.com/5b05351a47e02d6fe5ceb330/600x450/b9f4d5cb846c6a838e50ef0cb799d17e/1.JPG.jpg",
+        "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5b05351a47e02d6fe5ceb330/1200x900/f81104136dfa28fa261f1c8014358072/1.JPG.jpg",
+        "url": "https://trello-attachments.s3.amazonaws.com/5b053298bec3a1267125aa2c/5b05351a47e02d6fe5ceb330/621715ab655ef803fdf673f8fb4d50f6/1.JPG"
+      },
+      "board": {
+        "id": "5b053298bec3a1267125aa2c",
+        "name": "Sandbox",
+        "shortLink": "DBl4rcje"
+      },
+      "card": {
+        "id": "5b05351a47e02d6fe5ceb330",
+        "idShort": 1,
+        "name": "Test card",
+        "shortLink": "XhuRXEqB"
+      },
+      "list": {
+        "id": "5b053298bec3a1267125aa2d",
+        "name": "To Do"
+      }
+    },
+    "date": "2018-05-23T09:33:45.795Z",
+    "display": {
+      "entities": {
+        "attachment": {
+          "edgeColor": "#acb4ac",
+          "id": "5b053579753db133b2341d3d",
+          "link": true,
+          "previewUrl": "https://trello-attachments.s3.amazonaws.com/5b05351a47e02d6fe5ceb330/600x450/b9f4d5cb846c6a838e50ef0cb799d17e/1.JPG.jpg",
+          "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5b05351a47e02d6fe5ceb330/1200x900/f81104136dfa28fa261f1c8014358072/1.JPG.jpg",
+          "text": "1.JPG",
+          "type": "attachment",
+          "url": "https://trello-attachments.s3.amazonaws.com/5b053298bec3a1267125aa2c/5b05351a47e02d6fe5ceb330/621715ab655ef803fdf673f8fb4d50f6/1.JPG"
+        },
+        "attachmentPreview": {
+          "edgeColor": "#acb4ac",
+          "id": "5b053579753db133b2341d3d",
+          "originalUrl": "https://trello-attachments.s3.amazonaws.com/5b053298bec3a1267125aa2c/5b05351a47e02d6fe5ceb330/621715ab655ef803fdf673f8fb4d50f6/1.JPG",
+          "previewUrl": "https://trello-attachments.s3.amazonaws.com/5b05351a47e02d6fe5ceb330/600x450/b9f4d5cb846c6a838e50ef0cb799d17e/1.JPG.jpg",
+          "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5b05351a47e02d6fe5ceb330/1200x900/f81104136dfa28fa261f1c8014358072/1.JPG.jpg",
+          "type": "attachmentPreview"
+        },
+        "card": {
+          "id": "5b05351a47e02d6fe5ceb330",
+          "shortLink": "XhuRXEqB",
+          "text": "Test card",
+          "type": "card"
+        },
+        "memberCreator": {
+          "id": "57efc1789e71fbcbdcb303aa",
+          "text": "James Hiew",
+          "type": "member",
+          "username": "jameshiew1"
+        }
+      },
+      "translationKey": "action_add_attachment_to_card"
+    },
+    "id": "5b053579753db133b2341d44",
+    "idMemberCreator": "57efc1789e71fbcbdcb303aa",
+    "limits": {},
+    "memberCreator": {
+      "avatarHash": null,
+      "avatarUrl": null,
+      "fullName": "James Hiew",
+      "id": "57efc1789e71fbcbdcb303aa",
+      "initials": "JH",
+      "username": "jameshiew1"
+    },
+    "type": "addAttachmentToCard"
+  },
+  "model": {
+    "closed": false,
+    "desc": "",
+    "descData": null,
+    "id": "5b053298bec3a1267125aa2c",
+    "idOrganization": null,
+    "labelNames": {
+      "black": "",
+      "blue": "",
+      "green": "",
+      "lime": "",
+      "orange": "",
+      "pink": "",
+      "purple": "",
+      "red": "",
+      "sky": "",
+      "yellow": ""
+    },
+    "name": "Sandbox",
+    "pinned": false,
+    "prefs": {
+      "background": "5b02be9f4b55b57002664abe",
+      "backgroundBottomColor": "#343834",
+      "backgroundBrightness": "dark",
+      "backgroundImage": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1919/dc7b9ee28d5e6caf1580a5fa3a59f017/photo-1526715058896-23f69a067d99",
+      "backgroundImageScaled": [
+        {
+          "height": 100,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/133x100/ede5372a78f455f09a0338fae33fb1f5/photo-1526715058896-23f69a067d99.jpg",
+          "width": 133
+        },
+        {
+          "height": 192,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/256x192/d98fbce9f82dbfd9a968a46ffc57b7fa/photo-1526715058896-23f69a067d99.jpg",
+          "width": 256
+        },
+        {
+          "height": 360,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/480x360/eaf82149e38fba9c9a195fb05eea6a75/photo-1526715058896-23f69a067d99.jpg",
+          "width": 480
+        },
+        {
+          "height": 720,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/960x720/02d1eaa0b5e2c9af5072e3140685eec9/photo-1526715058896-23f69a067d99.jpg",
+          "width": 960
+        },
+        {
+          "height": 768,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1024x768/0c2d597a5c39ebe253f00bd58ec9e58a/photo-1526715058896-23f69a067d99.jpg",
+          "width": 1024
+        },
+        {
+          "height": 1535,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2048x1535/ad54991409cf9f2fb058c29fa35e2ebc/photo-1526715058896-23f69a067d99.jpg",
+          "width": 2048
+        },
+        {
+          "height": 960,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1280x960/c87a2b153108987a6095faf02e75772a/photo-1526715058896-23f69a067d99.jpg",
+          "width": 1280
+        },
+        {
+          "height": 1439,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1920x1439/b75bf869ad530f9571730e55e52d3bf9/photo-1526715058896-23f69a067d99.jpg",
+          "width": 1920
+        },
+        {
+          "height": 1600,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2134x1600/6fa6ea1443f6601a23f97373742c4b33/photo-1526715058896-23f69a067d99.jpg",
+          "width": 2134
+        },
+        {
+          "height": 1919,
+          "url": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1919/dc7b9ee28d5e6caf1580a5fa3a59f017/photo-1526715058896-23f69a067d99",
+          "width": 2560
+        }
+      ],
+      "backgroundTile": false,
+      "backgroundTopColor": "#46423d",
+      "calendarFeedEnabled": false,
+      "canBeOrg": true,
+      "canBePrivate": true,
+      "canBePublic": true,
+      "canInvite": true,
+      "cardAging": "regular",
+      "cardCovers": true,
+      "comments": "members",
+      "invitations": "members",
+      "permissionLevel": "private",
+      "selfJoin": false,
+      "voting": "disabled"
+    },
+    "shortUrl": "https://trello.com/b/DBl4rcje",
+    "url": "https://trello.com/b/DBl4rcje/sandbox"
+  }
+}

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -332,10 +332,4 @@ class CallbackEventModelTest(TestCase):
         ce = CallbackEvent()
         self.assertEqual(ce.card_name, None)
         ce.event_payload = get_sample_data('createCard', 'text')
-        self.assertEqual(ce.card_name, ce.event_payload['action']['data']['card']['name'])  # noqa\
-
-    def test_card_name(self):
-        ce = CallbackEvent()
-        self.assertEqual(ce.card_name, None)
-        ce.event_payload = get_sample_data('createCard', 'text')
         self.assertEqual(ce.card_name, ce.event_payload['action']['data']['card']['name'])  # noqa

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -272,6 +272,12 @@ class CallbackEventModelTest(TestCase):
         ce.event_payload = get_sample_data('createCard', 'text')
         self.assertEqual(ce.member, ce.event_payload['action']['memberCreator'])
 
+    def test_attachment(self):
+        ce = CallbackEvent()
+        self.assertEqual(ce.attachment, None)
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        self.assertEqual(ce.attachment, ce.event_payload['action']['data']['attachment'])  # noqa
+
     def test_board(self):
         ce = CallbackEvent()
         self.assertEqual(ce.board, None)
@@ -307,6 +313,12 @@ class CallbackEventModelTest(TestCase):
         self.assertEqual(ce.list_name, None)
         ce.event_payload = get_sample_data('createCard', 'text')
         self.assertEqual(ce.list_name, ce.event_payload['action']['data']['list']['name'])  # noqa
+
+    def test_card_name(self):
+        ce = CallbackEvent()
+        self.assertEqual(ce.card_name, None)
+        ce.event_payload = get_sample_data('createCard', 'text')
+        self.assertEqual(ce.card_name, ce.event_payload['action']['data']['card']['name'])  # noqa\
 
     def test_card_name(self):
         ce = CallbackEvent()

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -2,7 +2,6 @@
 import datetime
 import json
 import mock
-import requests
 import responses
 
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
I need to learn - how to better rebase so that dead code can be removed straight up rather than in extra commits